### PR TITLE
Parser fix and consider Single timestamp 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work.sum
 
 # env file
 .env
+
+# Working Copy or Store Log files
+wc/

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -12,12 +12,12 @@ import (
 
 // Log field regular expressions
 var (
-	dateTimeRegex     = regexp.MustCompile(`^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}(?:Z|[-+]\d{4})$`)
-	logLevelRegex     = regexp.MustCompile(`^(?:TRACE|DEBUG|INFO|WARN|ERROR|FATAL)$`)
-	loggerRegex       = regexp.MustCompile(`^[a-zA-Z0-9_\.-]+$`)
-	filePositionRegex = regexp.MustCompile(`^.*:\d+$`)
-	messageRegex      = regexp.MustCompile(`^[A-Za-z0-9\s\-\/:()]+$`)
-	detailsJSONRegex  = regexp.MustCompile(`^{.*}$`)
+	dateTimeRegex     = regexp.MustCompile(`^\s*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z)\s*`)
+	logLevelRegex     = regexp.MustCompile(`^\s*(?:TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\s*$`)
+	loggerRegex       = regexp.MustCompile(`^\s*[a-zA-Z0-9_\.-]+\s*$`)
+	filePositionRegex = regexp.MustCompile(`^\s*.*:\d+\s*$`)
+	messageRegex      = regexp.MustCompile(`^\s*[A-Za-z0-9\s\-\/:()]+\s*$`)
+	detailsJSONRegex  = regexp.MustCompile(`^\s*\{.*\}\s*$`)
 )
 
 // Field type constants

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -98,10 +98,18 @@ func (p *LogParser) ParseLine(line string) models.LogEntry {
 	finalParts := make([]string, 0)
 
 	var fieldPosAdjustment int
+	var isTimestampAlreadyFound = false
 	// Validate each part
 	for i, part := range parts {
 		fieldType := determineField(part)
 		expectedType := expectedFieldType(i + fieldPosAdjustment)
+		if fieldType == dateTimeField {
+			if isTimestampAlreadyFound {
+				// Ignore the second timestamp
+				continue
+			}
+			isTimestampAlreadyFound = true
+		}
 		if expectedType == messageField || expectedType == detailsJSONField {
 			finalParts = append(finalParts, part)
 			continue


### PR DESCRIPTION
This adds parser fix for two different timezones, ignore whitespaces and considers only single TimeStamp for processing - the first one in the list 